### PR TITLE
encapsulate data with quotation marks

### DIFF
--- a/admin/js/bp-xprofile-export-import-admin.js
+++ b/admin/js/bp-xprofile-export-import-admin.js
@@ -391,7 +391,7 @@ function JSONToCSVConvertor(JSONData){
 		var rowText = "";
 
 		for (var index in allData[i]) {
-			rowText += '' + allData[i][index] + ',';
+			rowText += '"' + allData[i][index] + '",';
 		}
 
 		rowText.slice( 0, rowText.length - 1 );


### PR DESCRIPTION
Thank you for your helpful plugin!  It mostly worked for me, but I had trouble with fields that contained commas and carriage returns.  This patch encapsulates fields in quotation marks for proper handling.